### PR TITLE
Fix installing iree-turbine

### DIFF
--- a/models/requirements.txt
+++ b/models/requirements.txt
@@ -12,5 +12,5 @@ azure-storage-blob
 einops
 pytest
 scipy
-shark-turbine @ git+https://github.com/iree-org/iree-turbine.git@main
+iree-turbine @ git+https://github.com/iree-org/iree-turbine.git@main
 -e git+https://github.com/nod-ai/sharktank.git@main#egg=sharktank&subdirectory=sharktank


### PR DESCRIPTION
The package name was changed from `shark-turbine` to `iree-turbine` with iree-org/iree-turbine@40016ad.